### PR TITLE
Fix webhook transaction matching for concurrent payment attempts

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -176,7 +176,7 @@ class Gateway extends OffsiteGateway
 
         $transactionHash = $this->getTransactionHashFromWebhook();
         if (!$transactionHash) {
-            $response->data = "No transactionHash passed.";
+            $response->data = "No matching transaction found.";
 
             return $response;
         }
@@ -251,10 +251,36 @@ class Gateway extends OffsiteGateway
 
     public function getTransactionHashFromWebhook()
     {
-        $orderRef = Craft::$app->getRequest()->getBodyParam('orderRef');
-        $order = SimplePayHelper::getOrderByOrderRef($orderRef);
+        $request = Craft::$app->getRequest();
+        $orderRef = (string) $request->getBodyParam('orderRef');
+        $transactionId = (string) $request->getBodyParam('transactionId');
 
-        return $order->getLastTransaction()->hash;
+        if (!$orderRef || !$transactionId) {
+            return null;
+        }
+
+        $order = SimplePayHelper::getOrderByOrderRef($orderRef);
+        $transactions = Commerce::getInstance()
+            ->getTransactions()
+            ->getAllTopLevelTransactionsByOrderId($order->id);
+
+        foreach ($transactions as $transaction) {
+            if (!$transaction->response) {
+                continue;
+            }
+
+            $response = json_decode($transaction->response, true);
+            if (!is_array($response)) {
+                continue;
+            }
+
+            if ((string)($response['orderRef'] ?? '') === $orderRef &&
+                (string)($response['transactionId'] ?? '') === $transactionId) {
+                return $transaction->hash;
+            }
+        }
+
+        return null;
     }
 
     // Protected Methods


### PR DESCRIPTION
## What changed

Port the webhook transaction matching fix to the `craft-3` branch.

Webhook handling now matches the incoming SimplePay IPN to the exact top-level Craft Commerce transaction using both the stored `orderRef` and `transactionId` from the original redirect response.

## Why

With multiple payment attempts for the same order, `$order->getLastTransaction()` can point to a different SimplePay transaction than the one reported by the IPN. This was observed with two purchase/redirect transactions created in the same second, where the successful SimplePay callback was attached to the wrong Commerce parent transaction.

## Implementation

`getTransactionHashFromWebhook()` now:

- resolves the order from the incoming `orderRef`;
- iterates over top-level Commerce transactions for that order;
- decodes each stored gateway response;
- requires both `orderRef` and `transactionId` to match the incoming IPN;
- returns no match instead of falling back to the latest transaction.

The change keeps the Craft 3 branch's existing method signatures and compatibility constraints.